### PR TITLE
Solving issue #9 ('close tab' button on Windows)

### DIFF
--- a/src/main/python/gui/location_definer.py
+++ b/src/main/python/gui/location_definer.py
@@ -436,7 +436,11 @@ class LocationDefinerTabWidget(QTabWidget):
 
         self.number_pages = len(self.location_definer_pages)
         self.addTab(QWidget(), QIcon(self.app_ctx.icons['plus']), 'Add location')
-        self.tabbar.tabButton(3, QTabBar.LeftSide).hide()
+        # hide close button for the '' tab. The location of the close button is OS-dependent.
+        if os.name == 'nt':  # For Windows, buttons appear on the right
+            self.tabbar.tabButton(3, QTabBar.RightSide).hide()
+        elif os.name == 'posix':  # For Linux and MacOS, they are on the left
+            self.tabbar.tabButton(3, QTabBar.LeftSide).hide()
 
     def add_location_tab(self, index):
         self.number_pages += 1


### PR DESCRIPTION
The issue arose because the close button, which is expected to be on the left-hand side, does not exist on Windows -- thus nothing to hide.

Instead, the close button appears on the **right-hand** side on Windows, unlike macOS and Linux. This commit added conditionals to check the os and call the button location accordingly.

There seems to be only one case that the button location is called, so that issue would not arise elsewhere.

![image](https://user-images.githubusercontent.com/43150234/105143637-f53b9a00-5ab0-11eb-95ae-b4d83dadf243.png)
